### PR TITLE
Update pom.xml using https

### DIFF
--- a/jimureport-example/pom.xml
+++ b/jimureport-example/pom.xml
@@ -21,7 +21,7 @@
         <repository>
             <id>aliyun</id>
             <name>aliyun Repository</name>
-            <url>http://maven.aliyun.com/nexus/content/groups/public</url>
+            <url>https://maven.aliyun.com/nexus/content/groups/public</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -29,7 +29,7 @@
         <repository>
             <id>jeecg</id>
             <name>jeecg Repository</name>
-            <url>http://maven.jeecg.org/nexus/content/repositories/jeecg</url>
+            <url>https://maven.jeecg.org/nexus/content/repositories/jeecg</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
高版本maven工具强制使用https协议，详见https://github.com/jeecgboot/JimuReport/issues/653
Update pom.xml using https